### PR TITLE
Remove local, temporary files from compilation

### DIFF
--- a/ComicBookGallery/ComicBookGallery.csproj
+++ b/ComicBookGallery/ComicBookGallery.csproj
@@ -173,9 +173,6 @@
     </Compile>
     <Compile Include="Models\Artist.cs" />
     <Compile Include="Models\ComicBook.cs" />
-    <Compile Include="obj\Debug\TemporaryGeneratedFile_036C0B5B-1481-4323-8D20-8F5ADCB23D92.cs" />
-    <Compile Include="obj\Debug\TemporaryGeneratedFile_5937a670-0e60-4077-877b-f7221da3dda1.cs" />
-    <Compile Include="obj\Debug\TemporaryGeneratedFile_E7A71F73-0F8D-4B9B-B56E-8E70B10BC5D3.cs" />
     <Compile Include="Properties\AssemblyInfo.cs" />
   </ItemGroup>
   <ItemGroup>


### PR DESCRIPTION
Change needed to freshly build the project, since `obj/` dir doesn't exist when you first clone the repository.